### PR TITLE
Add parameter for required revive items

### DIFF
--- a/description.ext
+++ b/description.ext
@@ -326,4 +326,31 @@ class Params
 		default = 0;
 	};
 
+	class REVIVE_LABEL
+	{
+		title = "===== Revive Settings ======";
+		values[] = {0};
+		texts[] = {""};
+		default = 0;
+	};
+
+	class ReviveRequiredItems
+	{
+		title = "Required items";
+		isGlobal = 1;
+
+		values[] = {
+			0,
+			1,
+			2
+		};
+		texts[] = {
+			"None",
+			"Medikit",
+			"First Aid Kit / Medikit"
+		};
+		default = 2;
+		function = "bis_fnc_paramReviveRequiredItems";
+	};
+
 };


### PR DESCRIPTION
In this mission the revive system is configured such that a player needs either a First Aid Kit or a Medikit to revive others. That's absolutely fine, but it did lead to some frustration and people thinking the revive system was broken.

This adds a new lobby parameter where the host can select that nothing, a Medikit, or a First Aid Kit / Medikit is required to revive players. The default is still First Aid Kit / Medikit as before, so this doesn't change the gameplay without intervention by the host.

We tested it on a dedicated server, everything seems to be working fine.