### PR TITLE
Fix area enforcement blur effect

### DIFF
--- a/area/Functions.hpp
+++ b/area/Functions.hpp
@@ -1,0 +1,8 @@
+class area
+{
+    class globals
+    {
+        file = "area\functions";
+        class createBlur {};
+    };
+};

--- a/area/areaEnforcement.sqf
+++ b/area/areaEnforcement.sqf
@@ -17,24 +17,7 @@ while {true} do {
                 _newLoc = bulwarkCity getPos [(BULWARK_RADIUS * 1.1)-8, _dir];
                 _x setPosASL _newLoc;
                 [_x, "teleportHit"] remoteExec ["sound_fnc_say3DGlobal", 0];
-                0 = ["DynamicBlur", 200, [10]] spawn {
-                    params ["_name", "_priority", "_effect", "_handle"];
-                    while {
-                        _handle = ppEffectCreate [_name, _priority];
-                        _handle < 0
-                    } do {
-                            _priority = _priority + 1;
-                    };
-                    _handle ppEffectEnable true;
-                    _handle ppEffectAdjust [10];
-                    _handle ppEffectCommit 0;
-                    waitUntil {ppEffectCommitted _handle};
-                    _handle ppEffectAdjust [0];
-                    _handle ppEffectCommit 1;
-                    waitUntil {ppEffectCommitted _handle};
-                    _handle ppEffectEnable false;
-                    ppEffectDestroy _handle;
-                };
+                ["DynamicBlur", 200, [10]] remoteExec ["area_fnc_createBlur", _x];
             };
 
             // Warn the player that they're too far from the centre

--- a/area/functions/fn_createBlur.sqf
+++ b/area/functions/fn_createBlur.sqf
@@ -1,0 +1,24 @@
+/**
+*  fn_createBlur
+*
+*  Creates DynamicBlur effect.
+*
+*  Domain: Client
+**/
+
+params ["_name", "_priority", "_effect", "_handle"];
+while {
+    _handle = ppEffectCreate [_name, _priority];
+    _handle < 0
+} do {
+    _priority = _priority + 1;
+};
+_handle ppEffectEnable true;
+_handle ppEffectAdjust [10];
+_handle ppEffectCommit 0;
+waitUntil {ppEffectCommitted _handle};
+_handle ppEffectAdjust [0];
+_handle ppEffectCommit 1;
+waitUntil {ppEffectCommitted _handle};
+_handle ppEffectEnable false;
+ppEffectDestroy _handle;

--- a/description.ext
+++ b/description.ext
@@ -29,6 +29,7 @@ class CfgFunctions
 	#include "supports\Functions.hpp"
 	#include "bulwark\Functions.hpp"
 	#include "sound\Functions.hpp"
+	#include "area\Functions.hpp"
 };
 
 
@@ -48,6 +49,7 @@ class CfgRemoteExec
 		class airStrike {};
 		class ragePack {};
 		class say3DGlobal {};
+		class createBlur {};
 	};
 };
 

--- a/initServer.sqf
+++ b/initServer.sqf
@@ -32,5 +32,5 @@ setDate [2018, 7, 1, _timeToSet, 0];
 [] execVM "revivePlayers.sqf";
 [bulwarkRoomPos] execVM "missionLoop.sqf";
 
-[] execVM "areaEnforcement.sqf";
+[] execVM "area\areaEnforcement.sqf";
 [] execVM "hostiles\clearStuck.sqf";


### PR DESCRIPTION
The area enforcement script runs on the server. When a player leaves the area, they are pushed back, a sound is played and a blur effect is created.

While the sound is correctly played by remotely executing it globally, the blur effect was created locally on the machine where the script runs, which is the server. This is not noticeable when hosting from the game, because then you are the server and the effect works if you walk out. For all other players though (or when playing on a dedicated server), it does not because they are not the host. When we played on a dedicated server and somebody would move out of the area, they didn't get the blur effect and on the server the script failed with the error message
```
21:47:06   Error Undefined variable in expression: _handle
21:47:06 File mpmissions\__cur_mp.Tanoa\areaEnforcement.sqf, line 31
21:47:06 Error in expression <tCommit 0;
waitUntil {ppEffectCommitted _handle};
_handle ppEffectAdjust [0];
_h>
```
because it tried to create the effect on the server, which doesn't have a display.

The fix is to remotely execute the blur effect creation on the offending client. To do that, I moved the area enforcement script into its own directory and broke out the blur effect creation into a separate function in order to add it to CfgRemoteExec.

Tested on dedicated server and while hosting from game.