### PR TITLE
areaEnforcement loop to trigger, some Fixes and Refactoring

### DIFF
--- a/area/Functions.hpp
+++ b/area/Functions.hpp
@@ -4,5 +4,6 @@ class area
     {
         file = "area\functions";
         class createBlur {};
+		class enforcement {};
     };
 };

--- a/area/functions/fn_enforcement.sqf
+++ b/area/functions/fn_enforcement.sqf
@@ -1,0 +1,48 @@
+/**
+*  fn_enforcement
+*
+*  reset player when leaving area
+*
+*  Domain: Server
+**/
+
+_player = _this select 0;
+
+_leaving = true;
+
+while {_leaving} do {
+	_dist = _player distance2D bulwarkCity;
+	switch true do {
+
+		// If player is WAYYY outside the bounds. Move them to the bulwark
+		case (_dist > BULWARK_RADIUS * 2): {
+			_newLoc = [bulwarkBox] call bulwark_fnc_findPlaceAround;
+			_player setPosASL _newLoc;
+		};
+
+		// If player is trying to leave, bounce them back.
+		case (_dist > BULWARK_RADIUS * 1.1): {
+			_dir = bulwarkCity getDir _player;
+			_newLoc = bulwarkCity getPos [(BULWARK_RADIUS * 1.1)-8, _dir];
+			_player setPosASL _newLoc;
+			[_player, "teleportHit"] remoteExec ["sound_fnc_say3DGlobal", 0];
+			["DynamicBlur", 200, [10]] remoteExec ["area_fnc_createBlur", _player];
+		};
+
+		// Warn the player that they're too far from the centre
+		case (_dist > BULWARK_RADIUS * 0.99): {
+			["<t color='#ff0000'>Warning: Leaving mission area!</t>", 0, 0.1, 2, 0] remoteExec ["BIS_fnc_dynamicText", _player];
+		};
+		case (_dist > BULWARK_RADIUS * 0.95): {
+			["<t color='#ffff00'>Warning: Leaving mission area!</t>", 0, 0.1, 2, 0] remoteExec ["BIS_fnc_dynamicText", _player];
+		};
+		case (_dist > BULWARK_RADIUS * 0.9): {
+			["<t color='#ffffff'>Warning: Leaving mission area!</t>", 0, 0.1, 2, 0] remoteExec ["BIS_fnc_dynamicText", _player];
+		};
+
+		default {
+			_leaving = false
+		};
+	};
+	sleep 1;
+};

--- a/bulwark/Functions.hpp
+++ b/bulwark/Functions.hpp
@@ -9,5 +9,7 @@ class bulwark
         class purchaseGui {};
         class roomCentre {};
         class roomVolume {};
+		class startWave {};
+		class endWave {}
     };
 };

--- a/bulwark/createBase.sqf
+++ b/bulwark/createBase.sqf
@@ -24,6 +24,8 @@ while {_isWater} do {
 	_isWater = surfaceIsWater (getPos bulwarkBox);
 };
 
+publicVariable "bulwarkCity";
+
 clearItemCargoGlobal bulwarkBox;
 clearWeaponCargoGlobal bulwarkBox;
 clearMagazineCargoGlobal bulwarkBox;

--- a/bulwark/functions/fn_endWave.sqf
+++ b/bulwark/functions/fn_endWave.sqf
@@ -1,0 +1,24 @@
+/**
+*  fn_endWave
+*
+*  Wave ended (mission complete)
+*
+*  Domain: Server
+**/
+
+bulwarkBox setVariable ["buildPhase", true, true];
+
+["TaskSucceeded",["Complete","Wave " + str attkWave + " complete!"]] remoteExec ["BIS_fnc_showNotification", 0];
+[0] remoteExec ["setPlayerRespawnTime", 0];
+
+{
+	// Try to force the spectator mode off when players are revived.
+	["Terminate"] remoteExec ["BIS_fnc_EGSpectator", _x];
+
+	// Revive players that died at the end of the round.
+	if ((lifeState _x == "DEAD") || (lifeState _x == "INCAPACITATED")) then {
+		forceRespawn _x;
+	};
+} foreach allPlayers;
+
+sleep _downTime;

--- a/bulwark/functions/fn_startWave.sqf
+++ b/bulwark/functions/fn_startWave.sqf
@@ -1,0 +1,65 @@
+/**
+*  fn_startWave
+*
+*  starts a new Wave
+*
+*  Domain: Server
+**/
+
+[] remoteExec ["killPoints_fnc_updateHud", 0];
+
+for ("_i") from 0 to 14 do {
+	if(_i > 10) then {"beep_target" remoteExec ["playsound", 0];} else {"readoutClick" remoteExec ["playsound", 0];};
+	[format ["<t>%1</t>", 15-_i], 0, 0, 1, 0] remoteExec ["BIS_fnc_dynamicText", 0];
+	sleep 1;
+};
+
+attkWave = (attkWave + 1);
+publicVariable "attkWave";
+
+[] remoteExec ["killPoints_fnc_updateHud", 0];
+
+["TaskAssigned",["In-coming","Wave " + str attkWave]] remoteExec ["BIS_fnc_showNotification", 0];
+	_respawnTickets = [west] call BIS_fnc_respawnTickets;
+	if (_respawnTickets <= 0) then {
+		RESPAWN_TIME = 99999;
+		publicVariable "RESPAWN_TIME";
+	};
+[RESPAWN_TIME] remoteExec ["setPlayerRespawnTime", 0];
+
+bulwarkBox setVariable ["buildPhase", false, true];
+
+//determine if suicide bomber round
+if ((attkWave > 15) && (floor random 10 == 1) && (_specialWaves == 1)) then {
+	suicideWave = true;
+	execVM "hostiles\suicideWave.sqf";
+	execVM "hostiles\suicideAudio.sqf";
+} else {
+	suicideWave = false;
+};
+
+//Notify start of wave and type of wave
+if (suicideWave) then {
+	["SpecialWarning",["SUICIDE BOMBERS! Don't Let Them Get Close!"]] remoteExec ["BIS_fnc_showNotification", 0];
+	["Alarm"] remoteExec ["playSound", 0];
+} else {
+	["TaskAssigned",["In-coming","Wave " + str attkWave]] remoteExec ["BIS_fnc_showNotification", 0];
+};
+
+// Delete
+_final = waveUnits select 2;
+{deleteVehicle _x} foreach _final;
+// Shuffle
+waveUnits set [2, waveUnits select 1];
+waveUnits set [1, waveUnits select 0];
+waveUnits set [0, []];
+// Spawn
+_createHostiles = execVM "hostiles\createWave.sqf";
+waitUntil {scriptDone _createHostiles};
+
+if (attkWave > 1) then { //if first wave give player extra time before spawning enemies
+	{deleteMarker _x} foreach lootDebugMarkers;
+	[] call loot_fnc_cleanup;
+	_spawnLoot = execVM "loot\spawnLoot.sqf";
+	waitUntil { scriptDone _spawnLoot};
+};

--- a/description.ext
+++ b/description.ext
@@ -32,6 +32,7 @@ class CfgFunctions
 	#include "area\Functions.hpp"
 	#include "build\Functions.hpp"
 	#include "hostiles\Functions.hpp"
+	#include "loot\Functions.hpp"
 };
 
 

--- a/initPlayerLocal.sqf
+++ b/initPlayerLocal.sqf
@@ -42,3 +42,11 @@ onEachFrame {
         drawIcon3D ["", [1,1,1,0.5], _textPos, 1, 1, 0, "Bulwark", 0, 0.04, "RobotoCondensed", "center", true];
     }
 };
+
+waitUntil {!isNil "bulwarkCity"}; 
+//areaEnforcement
+areaEnforcementTrigger = createTrigger ["EmptyDetector", bulwarkCity];
+areaEnforcementTrigger setTriggerArea [BULWARK_RADIUS * 0.9, BULWARK_RADIUS * 0.9, 0, false];
+areaEnforcementTrigger triggerAttachVehicle [player];
+areaEnforcementTrigger setTriggerActivation ["ANYPLAYER", "NOT PRESENT", true];
+areaEnforcementTrigger setTriggerStatements ["this", "[player] remoteExec ['area_fnc_enforcement', 2];", ""];

--- a/initServer.sqf
+++ b/initServer.sqf
@@ -34,5 +34,5 @@ setDate [2018, 7, 1, _timeToSet, 0];
 [] execVM "revivePlayers.sqf";
 [bulwarkRoomPos] execVM "missionLoop.sqf";
 
-[] execVM "area\areaEnforcement.sqf";
+//[] execVM "area\areaEnforcement.sqf";
 [] execVM "hostiles\clearStuck.sqf";

--- a/loot/Functions.hpp
+++ b/loot/Functions.hpp
@@ -1,0 +1,10 @@
+class loot
+{
+    class globals
+    {
+        file = "loot\functions";
+        class get {};
+        class cleanup {};
+        class deleteIfEmpty {};
+    };
+};

--- a/loot/functions/fn_cleanup.sqf
+++ b/loot/functions/fn_cleanup.sqf
@@ -1,0 +1,16 @@
+/**
+*  fn_cleanup
+*
+*  Removes all loot from Zone
+*
+*  Domain: Server
+**/
+
+//{deleteVehicle _x} foreach activeLoot;
+
+_loot = [] call loot_fnc_get;
+
+{ 
+	deleteVehicle _x;
+} forEach _loot
+

--- a/loot/functions/fn_deleteIfEmpty.sqf
+++ b/loot/functions/fn_deleteIfEmpty.sqf
@@ -1,0 +1,19 @@
+/**
+*  deleteIfEmpty
+*
+*  deletes the given container if it is empty
+*
+*  Domain: Client
+**/
+
+params ["_container"];
+
+if (
+	(magazineCargo _container isEqualTo [])
+	&& (weaponCargo _container isEqualTo []) 
+	&& (backpackCargo _container isEqualTo []) 
+	&& (itemCargo _container isEqualTo []) 
+	&& (everyContainer _container isEqualTo [])
+) then {
+	[_container] remoteExec ["deleteVehicle", 2];
+};

--- a/loot/functions/fn_get.sqf
+++ b/loot/functions/fn_get.sqf
@@ -6,4 +6,4 @@
 *  Domain: Client
 **/
 
-nearestObjects [bulwarkCity,["WeaponHolderSimulated","Box_C_UAV_06_Swifd_F","Land_Money_F"],BULWARK_RADIUS * 1.2];
+nearestObjects [bulwarkCity,["WeaponHolderSimulated_Scripted","Box_C_UAV_06_Swifd_F","Land_Money_F"],BULWARK_RADIUS * 1.2];

--- a/loot/functions/fn_get.sqf
+++ b/loot/functions/fn_get.sqf
@@ -1,0 +1,9 @@
+/**
+*  get
+*
+*  returns a list of all Loot in Zone
+*
+*  Domain: Client
+**/
+
+nearestObjects [bulwarkCity,["WeaponHolderSimulated","Box_C_UAV_06_Swifd_F","Land_Money_F"],BULWARK_RADIUS * 1.2];

--- a/loot/spawnLoot.sqf
+++ b/loot/spawnLoot.sqf
@@ -6,7 +6,7 @@
 *  Domain: Server
 **/
 
-activeLoot = [];
+//activeLoot = [];
 lootDebugMarkers = [];
 
 
@@ -20,7 +20,7 @@ _droneRoom = while {true} do {
 _droneSupport = createVehicle ["Box_C_UAV_06_Swifd_F", _droneRoom, [], 0, "CAN_COLLIDE"];
 [_droneSupport, ["<t color='#ff00ff'>" + "Reveal loot", "[ [],'supports\lootDrone.sqf'] remoteExec ['execVM',0];","",1,true,false,"true","true",2.5]] remoteExec ["addAction", 0, true];
 
-activeLoot pushback _droneSupport;
+//activeLoot pushback _droneSupport;
 
 // Item to give KillPoints (1 spawns every wave)
 _pointsLootRoom = while {true} do {
@@ -32,7 +32,7 @@ _pointsLootRoom = while {true} do {
 pointsLoot = createVehicle ["Land_Money_F", _pointsLootRoom, [], 0, "CAN_COLLIDE"];
 [pointsLoot, ["<t color='#00ff00'>" + "Collect Points", "loot\lootPoints.sqf","",1,true,false,"true","true",2.5]] remoteExec ["addAction", 0, true];
 
-activeLoot pushback pointsLoot;
+//activeLoot pushback pointsLoot;
 
 /* Master loot spawner */
 _houseCount = floor random 3; // Mix up the loot houses a bit
@@ -85,14 +85,13 @@ _roomCount = 0;
 				};
 				_lootHolder setPos [_lootRoomPos select 0, _lootRoomPos select 1, (_lootRoomPos select 2) + 0.1];
 
-				activeLoot pushback _lootHolder; // Add object to array for later cleanup
-
-				[_lootHolder, ["ContainerClosed", { // Add event to delete container if empty
-						params ["_container"];
-						if ((magazineCargo _container isEqualTo []) && (weaponCargo _container isEqualTo []) && (backpackCargo _container isEqualTo [])) exitWith {
-							[_container] remoteExec ["deleteVehicle", 2];
-						};
+				//activeLoot pushback _lootHolder; // Add object to array for later cleanup
+				
+				[_lootHolder, ['ContainerClosed', { // Add event to delete container if empty
+						params ['_container','_player'];
+						[_container] call loot_fnc_deleteIfEmpty;
 				}]] remoteExec ['addEventHandler', 0];
+
 			};
 		} forEach _lootRooms;
 	};

--- a/score/functions/fn_updateHud.sqf
+++ b/score/functions/fn_updateHud.sqf
@@ -21,7 +21,7 @@ if (!isDedicated) then {
     };
 
 	_respawnTickets = [west] call BIS_fnc_respawnTickets;
-	if(isNil "_respawnTickets") then {
+	if(isNil "_respawnTickets" || _respawnTickets < 0) then {
         _respawnTickets = 0;
     };
 

--- a/supports/lootDrone.sqf
+++ b/supports/lootDrone.sqf
@@ -14,6 +14,8 @@ _curWave = attkWave;
 
 ["IntelAdded",["Loot locations added to map"]] call BIS_fnc_showNotification;
 
+_loot = [] call loot_fnc_get;
+
 {
 	_displayName = "";
 	_mrkrName = format ["loot%1", _x];
@@ -47,7 +49,7 @@ _curWave = attkWave;
 		_mrkrName setMarkerText (str ((backpackCargo _x) select 0));
 	};
 	lootMrks pushback _mrkrName;
-} forEach activeLoot;
+} forEach _loot;
 
 waitUntil {_curWave != attkWave};
 {deleteMarker _x} forEach lootMrks;


### PR DESCRIPTION
- moved the area enforcement from loop to Trigger, so all players get a local Trigger created on init that will call the area_fnc_enforcement function if they leave the area in there is a loop that contains the areaEnforcement logic but will only run once per sec and only for players outside the area so should save a lot of servers load
- moved wave start and end logic into functions so this maybe can be called by trigger or event later.
- did some changes to the Loot:
  -  remove that activeLoot array and replaced it with a function (loot_fnc_get) that gets all lootHolder. this will give you an up to date list of lootHolders. 
  - as a side effect, the loot Drone won't show already picked up loot (maybe add a 5sec loop into loot drone logic that will keep it up to date). 
  - my main reason to restructure the loot logic was to fix the disappearing loot Bug and I think I've got it fixed. The problem was the ContainerClosed event handler that did not check for containers inside the container (added check for container and items).
- and I fixed display of negative Tickets