### PR TITLE
Bugfixes

### DIFF
--- a/missionLoop.sqf
+++ b/missionLoop.sqf
@@ -27,7 +27,7 @@ if (isServer) then {
 	execVM "loot\spawnLoot.sqf";
 };
 
-sleep 15;
+sleep _downTime;
 runMissionLoop = true;
 missionFailure = false;
 

--- a/onPlayerRespawn.sqf
+++ b/onPlayerRespawn.sqf
@@ -2,11 +2,11 @@ waitUntil {!isNil "bulwarkBox"};
 ["Terminate"] call BIS_fnc_EGSpectator;
 
 _player = _this select 0;
-removeHeadgear _player:
+removeHeadgear _player;
 removeGoggles _player;
 removeVest _player;
 removeBackpack _player;
-removeAllWeapons _player:
+removeAllWeapons _player;
 removeAllAssignedItems _player;
 _player setPosASL ([bulwarkBox] call bulwark_fnc_findPlaceAround);
 
@@ -17,13 +17,11 @@ if(PLAYER_STARTWEAPON) then {
 };
 
 if(PLAYER_STARTMAP) then {
-    _player addItem "ItemMap";
-    _player assignItem "ItemMap";
+    _player linkItem "ItemMap";
 };
 
 if(PLAYER_STARTNVG) then {
-    _player addItem "Integrated_NVG_F";
-    _player assignItem "Integrated_NVG_F";
+    _player linkItem "Integrated_NVG_F";
 };
 
 waituntil {alive _player};


### PR DESCRIPTION
1. Fixes #54 (aa87d16)
For some reason using `addItem` and `assignItem` were unreliable in MP. `linkItem` appears to work just fine.

2. Make the first break respect the downtime setting (b46bdab)
When the game begun, you only had a few seconds to find your first gun, which was quite annoying in places with sparse building density.